### PR TITLE
Multi-parent support

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -25,7 +25,7 @@ export class AppComponent {
     };
 
     initModel(r: Requirements) {
-        this.model.commit(m => m.mergeNodeDataArray(r))
+        this.model.commit(m => m.mergeNodeDataArray(r))   // ! currently broken due to multiple parents, fix when moved to non-TreeModel!
     }
 
   public setSelectedNode(node: go.Node) {

--- a/client/src/app/components/inspector/inspector.component.ts
+++ b/client/src/app/components/inspector/inspector.component.ts
@@ -14,7 +14,7 @@ export class InspectorComponent implements OnChanges {
 
     requirement: string = 'FINCH-TreeVisualizer-Placeholder';
     created_by: string = 'John Doe';
-    parent: string = 'FINCH-Team-Placeholder';
+    parent: string[] = ['FINCH-Team-Placeholder1', 'FINCH-Team-Placeholder2'];
     last_edited: Date | null = new Date();
     qualifier: string = 'SHALL';
     collection: string = 'Tree visualizer';
@@ -34,7 +34,7 @@ export class InspectorComponent implements OnChanges {
         if (val === null) {
             this.requirement = '-';
             this.created_by = '-';
-            this.parent = '-';
+            this.parent = ['-'];
             this.last_edited = null;
             this.qualifier = '-';
             this.collection = '-';
@@ -50,14 +50,14 @@ export class InspectorComponent implements OnChanges {
         }
         else {
             const data: Requirement = val.data;
-            const parent: go.Node | null = val.findTreeParentNode();
+            const parent: go.Node | null = val.findTreeParentNode();    // ! needs to be fixed after migration to non-TreeModel to support multiple parents
 
             this.requirement = data.title;
             this.created_by = data['created-by'];
             this.parent = parent ? parent.data.title : '';
             this.last_edited = new Date(data['last-edited']);
             this.qualifier = data.qualifier;
-            this.collection = data.collection.join(', ');
+            this.collection = data.collection;
             this.test_plans = data['test-plans'].length > 0 ? data['test-plans'] : [''];
             this.system = data.system;
             this.rationale = data.rationale;

--- a/client/src/app/interfaces/requirement.ts
+++ b/client/src/app/interfaces/requirement.ts
@@ -1,10 +1,10 @@
 export interface Requirement {
     id: string;
     'created-by': string;
-    'parent': string;
+    parent: Array<string>;
     'last-edited': Date;
     qualifier: string;
-    collection: Array<string>;
+    collection: string;
     'test-plans': Array<string>;
     system: string;
     rationale: string;

--- a/server/bin/www
+++ b/server/bin/www
@@ -86,5 +86,5 @@ function onListening() {
   var bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
-  debug('Listening on ' + bind);
+  console.info('Listening on addr ' + addr.address + ' bind ' + bind + '\n');
 }

--- a/server/src/services/notion.service.js
+++ b/server/src/services/notion.service.js
@@ -81,17 +81,17 @@ const _parseRequirementsForAPI = async function(raw_data) {
     data.push({
       'id': elem.id,
       'created-by': props['Created by'].created_by.name,
-      'parent': props.Parent.relation.map(r => r.id),
+      'parent': props.Parent.relation.map(r => r.id),                           // * list
       'last-edited': props['Last Edited'].last_edited_time,
       'qualifier': qualifiers[props['🛑 Qualifier'].relation?.[0]?.id] ?? '',   // Notion enforced limit 1
       'collection': props.Collection.select?.name ?? '',
-      'test-plans': props['🏁 Test Plans'].relation.map(r => test_plans[r.id]),  // * list
-      'system': systems[props['🏗️ System'].relation?.[0]?.id] ?? '',                  // Notion enforced limit 1
+      'test-plans': props['🏁 Test Plans'].relation.map(r => test_plans[r.id]), // * list
+      'system': systems[props['🏗️ System'].relation?.[0]?.id] ?? '',            // Notion enforced limit 1
       'rationale': props.Rationale.rich_text?.[0]?.plain_text ?? '',
-      'trades': props['🃏 Trades'].relation.map(r => trades[r.id]),      // * list
+      'trades': props['🃏 Trades'].relation.map(r => trades[r.id]),              // * list
       'last-edited-by': props['Last Edited By'].last_edited_by.name,
-      'stakeholder': props['⚽ Stakeholder'].relation.map(r => teams[r.id]),          // * list
-      'mission': missions[props['🏆 Mission'.relation?.[0]?.id]] ?? '',  // Notion enforced limit 1
+      'stakeholder': props['⚽ Stakeholder'].relation.map(r => teams[r.id]),    // * list
+      'mission': missions[props['🏆 Mission'.relation?.[0]?.id]] ?? '',         // Notion enforced limit 1
       'description': props.Description.rich_text?.[0]?.plain_text ?? '',
       'title': props.ID.title?.[0]?.plain_text ?? '',
       'url': elem.url

--- a/server/src/services/notion.service.js
+++ b/server/src/services/notion.service.js
@@ -81,10 +81,10 @@ const _parseRequirementsForAPI = async function(raw_data) {
     data.push({
       'id': elem.id,
       'created-by': props['Created by'].created_by.name,
-      'parent': props.Parent.relation?.[0]?.id ?? '',                     // Notion enforced limit 1
+      'parent': props.Parent.relation.map(r => r.id),
       'last-edited': props['Last Edited'].last_edited_time,
       'qualifier': qualifiers[props['🛑 Qualifier'].relation?.[0]?.id] ?? '',   // Notion enforced limit 1
-      'collection': props.Collection.multi_select.map(c => c.name),       // * list
+      'collection': props.Collection.select?.name ?? '',
       'test-plans': props['🏁 Test Plans'].relation.map(r => test_plans[r.id]),  // * list
       'system': systems[props['🏗️ System'].relation?.[0]?.id] ?? '',                  // Notion enforced limit 1
       'rationale': props.Rationale.rich_text?.[0]?.plain_text ?? '',
@@ -107,8 +107,8 @@ const _parseRequirementsForVis = async function(raw_data) {
   for (let elem of raw_data) {
     all_obj[elem.id] = {
       title: elem.properties['ID'].title[0]?.plain_text,
-      parent: elem.properties.Parent.relation[0]?.id,
-      children: elem.properties.Child.relation?.map(r => r.id)
+      parent: elem.properties.Parent.relation.map(r => r.id),
+      children: elem.properties.Child.relation.map(r => r.id)
     }
   }
 


### PR DESCRIPTION
Changes server Notion service, client `Requirement` interface, and some of `InspectorComponent` to support multiple parents. 

Note! There are some pending TODOs marked with `// !` that need to be completed after migration to `GraphLinks` model, as multiple parents are incompatible with current `TreeModel`, so client is current broken in this PR.